### PR TITLE
Fix when previewing another SVG file, a preview image is not updated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-svgviewer",
   "displayName": "SVG Viewer",
   "description": "SVG Viewer",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "publisher": "cssho",
   "engines": {
     "vscode": "^0.10.8"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,6 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         private createSvgSnippet() {
-
             return this.extractSnippet();
         }
 
@@ -74,6 +73,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     let open = vscode.commands.registerTextEditorCommand('svgviewer.open', (te, t) => {
         if (checkNoSvg(te)) return;
+        provider.update(previewUri);
         return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.Two)
             .then(s => console.log('done.'), vscode.window.showErrorMessage);
 


### PR DESCRIPTION
1. Open SVG file "A"
2. Preview "A" image
3. Close preview "A"
4. Open SVG file "B"
5. Preview "B" image, but display "A" image
