### PR TITLE
Add feature: Export PNG with Canvas Tag.

### DIFF
--- a/media/export.css
+++ b/media/export.css
@@ -1,0 +1,65 @@
+.svgbg[data-showtransgrid="true"] {
+    background:initial;
+    background-image: url(data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAeUlEQVRYR+3XMQ4AIQhEUTiU9+/hUGy9Wk2G8luDIS8EMWdmYvF09+JtEUmBpieCJiA96AIiiKAswEsik10JCCIoCrAsiGBPOIK2YFWt/knOOW5Nv/ykQNMTQRMwEERQFWAOqmJ3PIIIigIMahHs3ahZt0xCetAEjA99oc8dGNmnIAAAAABJRU5ErkJggg==);
+    background-position: left,top;
+}
+
+svg, #image {
+    display: none;
+}
+
+.form {
+    background-color: #2D2D30;
+    padding: 5px;
+    display: inline-block;
+}
+
+.label-name {
+    display: inline-block;
+    text-align: right;
+    width: 40px;
+}
+
+.wrapper {
+    display: inline-block;
+    background-color: #3c3c3c;
+    border: 1px solid transparent;
+    padding: 5px;
+}
+
+.active {
+    border: 1px solid rgba(14,99,156,.6);
+}
+
+input {
+    text-align: right;
+    background-color: transparent;
+    border-style: none;
+    color: inherit;
+    width: 60px;
+}
+
+input:focus {
+    outline: 0;
+}
+
+.button {
+    display: inline-block;
+    border: 1px;
+    padding: 5px;
+    background-color: #0e639c;
+    border: 1px solid #0e639c;
+    text-decoration: none;
+    color: inherit;
+    outline: 0;
+}
+
+.button:focus {
+    outline: 0;
+}
+
+.button[href="#"] {
+    background-color: gray;
+    border: 1px solid gray;
+    cursor: not-allowed;
+}

--- a/media/export.js
+++ b/media/export.js
@@ -1,0 +1,54 @@
+$(() => {
+    let $exprt = $('#export');
+    let $canvas = $('#canvas');
+    let $image = $('#image');
+    let $svg = $('svg');
+    let $width = $('#width');
+    let $height = $('#height');
+    $width.val(Math.round($svg.width()));
+    $height.val(Math.round($svg.height()));
+    $width.keyup(handler($width)).mouseup(handler($width));
+    $height.keyup(handler($height)).mouseup(handler($height));
+    update();
+
+    function update() {
+        let ew = parseInt($width.val(), 10), eh = parseInt($height.val(), 10);
+        $canvas.attr({width: ew, height: eh});
+        let context = $canvas[0].getContext('2d');
+        context.clearRect(0, 0, ew, eh);
+        let scale = Math.min(ew / $svg.width(), eh / $svg.height());
+        let sw = Math.round($svg.width() * scale);
+        let sh = Math.round($svg.height() * scale);
+        context.drawImage(
+            $image[0],
+            (ew - sw) / 2,
+            (eh - sh) / 2,
+            sw,
+            sh
+        );
+        let du = $canvas[0].toDataURL('image/png');
+        let args = {
+            du: du,
+            output: decodeURIComponent($exprt.data('output'))
+        };
+        $exprt.attr({href: 'command:svgviewer.savedu?'
+            + encodeURIComponent(JSON.stringify(args))});
+    }
+
+    function handler($elem) {
+        return function () {
+            if (parseInt($elem.val(), 10) > 0) {
+                return update();
+            }
+            $exprt.attr({href: '#'});
+        }
+    }
+});
+
+$(() => {
+    $('input').focusin(function () {
+        $(this).parent().addClass('active');
+    }).focusout(function () {
+        $(this).parent().removeClass('active');
+    })
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       {
         "command": "svgviewer.copydui",
         "title": "SVG Viewer: Copy data URI scheme"
+      },
+      {
+        "command": "svgviewer.openexport",
+        "title": "SVG Viewer: (Experimental) Export PNG"
       }
     ],
     "keybindings": [
@@ -74,6 +78,7 @@
   },
   "dependencies": {
     "copy-paste": "^1.1.4",
+    "jquery": "^3.1.0",
     "node-cmd": "^1.1.1",
     "path": "^0.12.7",
     "pn": "^1.0.0",

--- a/src/exportProvider.ts
+++ b/src/exportProvider.ts
@@ -27,7 +27,6 @@ export class ExportDocumentContentProvider implements vscode.TextDocumentContent
 
     private snippet(document: vscode.TextDocument): string {
         let showTransGrid = vscode.workspace.getConfiguration('svgviewer').get('transparencygrid');
-        let transGridCss = '';
         let css = `<link rel="stylesheet" type="text/css" href="${this.getPath('media/export.css')}">`;
         let jquery = `<script src="${this.getPath('node_modules/jquery/dist/jquery.js')}"></script>`;
         let exportjs = `<script src="${this.getPath('media/export.js')}"></script>`;

--- a/src/exportProvider.ts
+++ b/src/exportProvider.ts
@@ -1,0 +1,44 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export class ExportDocumentContentProvider implements vscode.TextDocumentContentProvider {
+    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+
+    public constructor(private _context: vscode.ExtensionContext) {}
+
+    public provideTextDocumentContent(uri: vscode.Uri): Thenable<string> {
+        let docUri = vscode.Uri.parse(uri.query);
+        return vscode.workspace.openTextDocument(docUri).then(document => this.snippet(document));
+    }
+
+    get onDidChange(): vscode.Event<vscode.Uri> {
+        return this._onDidChange.event;
+    }
+
+    public update(uri: vscode.Uri) {
+        this._onDidChange.fire(uri);
+    }
+
+    private getPath(p: string): string {
+        return path.join(this._context.extensionPath, p);
+    }
+
+    private snippet(document: vscode.TextDocument): string {
+        let showTransGrid = vscode.workspace.getConfiguration('svgviewer').get('transparencygrid');
+        let transGridCss = '';
+        let css = `<link rel="stylesheet" type="text/css" href="${this.getPath('media/export.css')}">`;
+        let jquery = `<script src="${this.getPath('node_modules/jquery/dist/jquery.js')}"></script>`;
+        let exportjs = `<script src="${this.getPath('media/export.js')}"></script>`;
+        let output = document.uri.fsPath.replace('.svg', '.png');
+        let exportButton = `<a id="export" data-output="${encodeURIComponent(output)}" href="#" class="button">Export PNG</a>`;
+        let canvas = `<canvas id="canvas" class="svgbg" data-showtransgrid="${showTransGrid}"></canvas>`;
+        let svg = document.getText();
+        let image = `<img id="image" src="${'data:image/svg+xml,' + encodeURIComponent(document.getText())}" alt="svg image" />`
+        let width = `<div class="wrapper"><label for="width" class="label-name">Width</label><input id="width" type="number" placeholder="width"><label for="width"> px</label></div>`;
+        let height = `<div class="wrapper"><label for="height" class="label-name">Height</label><input id="height" type="number" placeholder="height"><label for="height"> px</label></div>`;
+        let options = `<h1>Options</h1><div class="form">${width}${height}${exportButton}</div>`;
+        return `<!DOCTYPE html><html><head>${css}${jquery}${exportjs}</head><body>${options}<h1>Preview</h1><div>${svg}${image}${canvas}</div></body></html>`;
+    }
+}


### PR DESCRIPTION
Hello @cssho .

I' working on adding "SVG Viewer: (Experimental) Export PNG" command.
Using Canvas Html Tag to export PNG from SVG.
So this feature doesn't depends on `phantom-prebuilt`. 
# Use this feature
1.  Open a SVG file.
2.  Press `F1`.
3. Choose "SVG Viewer: (Experimental) Export PNG".
4. Change Width or Height if need.
5. Press 'Export PNG' button.
# Todo
- [x] show warning message when active editor is not svg
