### PR TITLE
Upgrade to TypeScript 2 and Fix a few Null Dereference Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.3.1",
     "publisher": "cssho",
     "engines": {
-        "vscode": "^0.10.8"
+        "vscode": "^1.9.0"
     },
     "categories": [
         "Other"

--- a/package.json
+++ b/package.json
@@ -87,13 +87,15 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "typescript": "^1.7.5",
-        "vscode": "^0.11.1"
+        "@types/mocha": "2.2.39",
+        "@types/node": "^7.0.5",
+        "typescript": "^2.2.1",
+        "vscode": "^1.0.4"
     },
     "dependencies": {
         "copy-paste": "^1.1.4",

--- a/src/svgProvider.ts
+++ b/src/svgProvider.ts
@@ -23,7 +23,7 @@ export class SvgDocumentContentProvider implements vscode.TextDocumentContentPro
 
     private extractSnippet(): string {
         let editor = vscode.window.activeTextEditor;
-        let text = editor.document.getText();
+        let text = editor ? editor.document.getText() : '';
         return this.snippet(text);
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,11 @@
 		"module": "commonjs",
 		"target": "es5",
 		"outDir": "out",
-		"noLib": true,
+		"lib": [
+			"es2015"
+		],
 		"sourceMap": true,
-        "rootDir": "."
+		"rootDir": "."
 	},
 	"exclude": [
 		"node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 			"es2015"
 		],
 		"sourceMap": true,
-		"rootDir": "."
+		"rootDir": ".",
+		"strictNullChecks": true
 	},
 	"exclude": [
 		"node_modules"

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
This change updates the extension to use TypeScript 2.2. It also enables the `strictNullChecks` compiler  flag and fixes a few paths where `activeTextEditor` is used without checking if it is undefined first.