### PR TITLE
Added context menu command to open SVG file with file-watcher enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "activationEvents": [
         "onLanguage:xml",
         "onCommand:svgviewer.open",
+        "onCommand:svgviewer.openfile",
         "onCommand:svgviewer.saveas",
         "onCommand:svgviewer.saveassize",
         "onCommand:svgviewer.copydui",
@@ -28,6 +29,10 @@
                     "light": "./media/preview-darkgray.svg",
                     "dark": "./media/preview-lightgray.svg"
                 }
+            },
+            {
+                "command": "svgviewer.openfile",
+                "title": "SVG Viewer: View SVG File"
             },
             {
                 "command": "svgviewer.saveas",
@@ -51,6 +56,11 @@
                 "when": "resourceLangId == xml",
                 "command": "svgviewer.open",
                 "group": "navigation"
+            }],
+            "explorer/context": [{
+                "command": "svgviewer.openfile",
+                "group": "extension",
+                "when": "resourceLangId  == xml"
             }]
         },
         "keybindings": [{


### PR DESCRIPTION
This commit adds an explorer context menu  for viewing an SVG file without opening it into an editor window. Plus, it watches this file for any changes. Thus if the file is changes from external programs the view is automatically updated.

My use case: I sometime use [diagrams](http://projects.haskell.org/diagrams/) library which can generate SVG diagrams using the [SVG backend](http://projects.haskell.org/diagrams/doc/manual.html#the-svg-backend). Which can run in a loop mode, so if I change the Haskell code for the diagram and save it, it will automatically re-built the file and generate SVG file. I would like the viewer to automatically update the view, so that I can change a Haskell file on left window and see the generated SVG on the right window without keep opening the additional editor window for the SVG file and clicking that window every time the file changes so that the view can catch the change. But there can be other use cases where other programs generating the SVG file rather than manually writing it.

Since the view window watches a file for changes, the viewer window is bound to the file and not the active editor in this case. Therefore I opted for context menu command. The context menu command is also helpful if someone just want to see the SVG output, they do not have to first open the file and then click on the icon to view the output.

This commit should not affect current functionalities of the extension. It just adds a new command. To check how it works you can install the extension from here: https://github.com/harmishhk/vscode-svgviewer/releases/tag/1.4.1.